### PR TITLE
Python add bankaccount repr

### DIFF
--- a/Python/kata/accountnumber.py
+++ b/Python/kata/accountnumber.py
@@ -20,5 +20,8 @@ class AccountNumber(object):
     def __hash__(self):
         return hash(self._number)
 
+    def __repr__(self):
+        return 'AccountNumber({!r})'.format(self._number)
+
     def __str__(self):
         return self._number

--- a/Python/kata/accountnumber.py
+++ b/Python/kata/accountnumber.py
@@ -8,7 +8,7 @@ class AccountNumber(object):
     def __init__(self, number):
         account_number_format = r'^\d{9}$'
         if not number or not re.match(account_number_format, number):
-            raise ValueError(number)
+            raise ValueError('invalid account number: {!r} (exactly 9 digits required)'.format(number))
 
         self._number = number
 

--- a/Python/test/test_accountnumber.py
+++ b/Python/test/test_accountnumber.py
@@ -5,24 +5,17 @@ from kata.accountnumber import AccountNumber
 
 
 class AccountNumberTestCase(unittest.TestCase):
-    def test_equal_in_list(self):
-        account_numbers = [AccountNumber("123456789")]
-
-        self.assertEqual(1, len(account_numbers))
-        self.assertEqual(AccountNumber("123456789"), account_numbers[0])
+    def test_equal(self):
+        self.assertEqual(AccountNumber("123456789"), AccountNumber("123456789"))
 
     def test_not_equal(self):
         self.assertNotEqual(AccountNumber("123456789"), AccountNumber("123456788"))
 
     def test_number_as_string(self):
-        account_number = AccountNumber("123456789")
-
-        self.assertEqual("123456789", str(account_number))
+        self.assertEqual("123456789", str(AccountNumber("123456789")))
 
     def test_repr(self):
-        account_number = AccountNumber("123456789")
-
-        self.assertEqual("AccountNumber('123456789')", repr(account_number))
+        self.assertEqual("AccountNumber('123456789')", repr(AccountNumber("123456789")))
 
     def test_validate_number_length(self):
         self.assertRaises(ValueError, lambda: AccountNumber("12345678"))

--- a/Python/test/test_accountnumber.py
+++ b/Python/test/test_accountnumber.py
@@ -19,6 +19,11 @@ class AccountNumberTestCase(unittest.TestCase):
 
         self.assertEqual("123456789", str(account_number))
 
+    def test_repr(self):
+        account_number = AccountNumber("123456789")
+
+        self.assertEqual("AccountNumber('123456789')", repr(account_number))
+
     def test_validate_number_length(self):
         self.assertRaises(ValueError, lambda: AccountNumber("12345678"))
 


### PR DESCRIPTION
Three minor changes, each in a separate commit in case you want to cherry pick.

---

With regards to `__repr__`:

See e.g. https://docs.python.org/3/library/functions.html#repr.

Instead of

```
>>> AccountNumber('123456789')
<accountnumber.AccountNumber at 0x7f4546a1e310>
```

we now get

```
>>> AccountNumber('123456789')
AccountNumber('123456789')
```
which makes more sense during inspection/debugging.